### PR TITLE
Add a tag combining the branch and commit.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -100,11 +100,12 @@ runs:
           
           tag_commit="${ECR_REGISTRY}/${ECR_REPOSITORY}:${COMMIT}" # use this to deploy
           tag_branch="${ECR_REGISTRY}/${ECR_REPOSITORY}:${branch}"
-          tag_legacy="${ECR_REGISTRY}/${ECR_REPOSITORY}:${APP_NAME}-${branch}-${COMMIT}"
+          tag_branch_commit="${ECR_REGISTRY}/${ECR_REPOSITORY}:${branch}-${COMMIT}"
           echo "Building image with tags [${tag_commit}, ${tag_branch}, ${tag_legacy}]"
           docker build \
             -t $tag_commit \
             -t $tag_branch \
+            -t $tag_branch_commit \
             --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$branch \
             --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:master \
             --label io.eb7.git_branch="$branch" \


### PR DESCRIPTION
This is needed so we can prevent production docker images tagged from the master branch from potentially expiring when we push more commits to the master branch.