### PR TITLE
Use docker/build-push-action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,9 +17,8 @@ inputs:
   secret:
     required: false
     description: >
-      allow providing --secret to the docker build command.
-      See https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information
-      for required changes to the Dockerfile.
+      allow providing secret values,
+      see https://github.com/docker/build-push-action/blob/master/docs/advanced/secrets.md
   secret-files:
     required: false
     description: >

--- a/action.yml
+++ b/action.yml
@@ -97,4 +97,6 @@ runs:
           build-args: ${{ inputs.build-args }}
           file: ${{ inputs.dockerfile-path }}
           secrets: ${{ inputs.secret }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 

--- a/action.yml
+++ b/action.yml
@@ -61,62 +61,40 @@ runs:
 
       - name: Build, tag, and push docker image to Amazon ECR
         shell: bash
+        id: config
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecr-repository }}
           COMMIT: ${{ steps.sha.outputs.sha_short}}
-          BUILDKIT_INLINE_CACHE: 1
-          DOCKER_BUILDKIT: 1
         run: |
           ref=${{ github.event.pull_request.head.ref }}
           [ -z "$ref" ] && ref=${{ github.ref }}
           build_timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")#
           branch=$(echo $ref | sed "s/refs\/heads\///g" | sed -r 's/[^-_.a-zA-Z0-9]+/_/g')
-
-          # Pull images to make caching work.
-          docker pull $ECR_REGISTRY/$ECR_REPOSITORY:$branch || docker pull $ECR_REGISTRY/$ECR_REPOSITORY:master || true
-
-          if [ -n '${{ inputs.build-args }}' ]
-          then
-            build_args_unparsed='${{ inputs.build-args }}'
-            # As of https://stackoverflow.com/questions/19771965/split-bash-string-by-newline-characters
-            DEFAULT_IFS=$IFS
-            IFS=$'\n' build_args_list=($build_args_unparsed)
-            IFS=$DEFAULT_IFS
-
-            set_additional_build_args=''
-            for item in ${build_args_list[@]}
-            do
-              set_additional_build_args="${set_additional_build_args} --build-arg ${item}"
-            done
-            echo "Using build argument(s): ${build_args_list[*]}"
-          fi
-
-          if [ -n '${{ inputs.secret }}' ]
-          then
-            echo "Using secret configuration: ${{ inputs.secret }}"
-            set_secret="--secret ${{ inputs.secret }}"
-          fi
           
           tag_commit="${ECR_REGISTRY}/${ECR_REPOSITORY}:${COMMIT}" # use this to deploy
           tag_branch="${ECR_REGISTRY}/${ECR_REPOSITORY}:${branch}"
           tag_branch_commit="${ECR_REGISTRY}/${ECR_REPOSITORY}:${branch}-${COMMIT}"
-          echo "Building image with tags [${tag_commit}, ${tag_branch}, ${tag_legacy}]"
-          docker build \
-            -t $tag_commit \
-            -t $tag_branch \
-            -t $tag_branch_commit \
-            --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:$branch \
-            --cache-from $ECR_REGISTRY/$ECR_REPOSITORY:master \
-            --label io.eb7.git_branch="$branch" \
-            --label io.eb7.log_format=json \
-            --label io.eb7.group=application \
-            --label org.label-schema.schema-version="1.0.0-rc.1" \
-            --label org.label-schema.vendor="e-bot7 GmbH" \
-            --label org.label-schema.build-date="$build_timestamp" \
-            --label org.label-schema.name="$ECR_REPOSITORY" \
-            -f ${{ inputs.dockerfile-path }} \
-            $set_additional_build_args \
-            $set_secret \
-            .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY --all-tags
+
+          echo "::set-output name=tags::$tag_commit,$tag_branch,$tag_branch_commit"
+          echo "::set-output name=build_timestamp::$build_timestamp"
+          echo "::set-output name=branch::$branch"
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.config.outputs.tags}}
+          labels: |
+            io.eb7.git_branch="${{ steps.config.outputs.branch}}"
+            io.eb7.log_format=json
+            io.eb7.group=application
+            org.label-schema.schema-version="1.0.0-rc.1"
+            org.label-schema.vendor="e-bot7 GmbH"
+            org.label-schema.build-date="${{ steps.config.outputs.build_timestamp}}"
+            org.label-schema.name="$ECR_REPOSITORY"
+          build-args: ${{ inputs.build-args }}
+          file: ${{ inputs.dockerfile-path }}
+          secrets: ${{ inputs.secret }}
+

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
         shell: bash
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
 
-      - name: Build, tag, and push docker image to Amazon ECR
+      - name: Configure docker image repositories and tags
         shell: bash
         id: config
         env:
@@ -87,7 +87,7 @@ runs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Build and push
+      - name: Build and push to ECR
         uses: docker/build-push-action@v2
         with:
           context: .

--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,9 @@ runs:
           echo "::set-output name=build_timestamp::$build_timestamp"
           echo "::set-output name=branch::$branch"
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,11 @@ inputs:
       allow providing --secret to the docker build command.
       See https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information
       for required changes to the Dockerfile.
+  secret-files:
+    required: false
+    description: >
+      allow providing a secret file, 
+      see https://github.com/docker/build-push-action/blob/master/docs/advanced/secrets.md
   aws-access-key-id:
     required: true
     description: aws creds to login to ecr repo
@@ -100,6 +105,7 @@ runs:
           build-args: ${{ inputs.build-args }}
           file: ${{ inputs.dockerfile-path }}
           secrets: ${{ inputs.secret }}
+          secret-files: ${{ inputs.secret-files }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 


### PR DESCRIPTION
By switching from directly running docker commands to the `docker/build-push-action`, we are also adding the ability to use the github actions cache as the storage for the docker cache, which greatly improves its performance.